### PR TITLE
Update module path for new URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/ThomsonReutersEikon/go-ntlm
+module github.com/git-lfs/go-ntlm

--- a/ntlm/crypto.go
+++ b/ntlm/crypto.go
@@ -10,7 +10,7 @@ import (
 	rc4P "crypto/rc4"
 	crc32P "hash/crc32"
 
-	md4P "github.com/ThomsonReutersEikon/go-ntlm/ntlm/md4"
+	md4P "github.com/git-lfs/go-ntlm/ntlm/md4"
 )
 
 func md4(data []byte) []byte {

--- a/utils/decode_auth.go
+++ b/utils/decode_auth.go
@@ -7,7 +7,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/ThomsonReutersEikon/go-ntlm/ntlm"
+	"github.com/git-lfs/go-ntlm/ntlm"
 )
 
 func main() {

--- a/utils/test_auth.go
+++ b/utils/test_auth.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/ThomsonReutersEikon/go-ntlm/ntlm"
+	"github.com/git-lfs/go-ntlm/ntlm"
 )
 
 func main() {


### PR DESCRIPTION
In order for people to be able to use this module from go.mod, update the name everywhere it's used.